### PR TITLE
Update openvpn Docker image to 2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "3.0"
 services:
   app:
-    image: kylemanna/openvpn:2.3
+    image: kylemanna/openvpn:2.4
     cap_add:
       - NET_ADMIN
     ports:


### PR DESCRIPTION
Fix warnings:

```
WARNING: INSECURE cipher with block size less than 128 bit (64 bit).
         This allows attacks like SWEET32.
         Mitigate by using a --cipher with a larger block size (e.g.
         AES-256-CBC).
WARNING: cipher with small block size in use, reducing reneg-bytes to
         64MB to mitigate SWEET32 attacks.
```